### PR TITLE
Fix inverted arguments in Titanic_Survival_Exploration.ipynb

### DIFF
--- a/projects/titanic_survival_exploration/Titanic_Survival_Exploration.ipynb
+++ b/projects/titanic_survival_exploration/Titanic_Survival_Exploration.ipynb
@@ -116,7 +116,7 @@
     "    \n",
     "# Test the 'accuracy_score' function\n",
     "predictions = pd.Series(np.ones(5, dtype = int))\n",
-    "print accuracy_score(predictions, outcomes[:5])"
+    "print accuracy_score(outcomes[:5], predictions)"
    ]
   },
   {


### PR DESCRIPTION
In Titanic_Survival_Exploration.ipynb, accuracy_score() expects the arguments
'truth, pred', but while calling the same function we have inverted the arguments.
Although this still works, its confusing and incorrect.