### PR TITLE
fix: Fix turning left/right bug

### DIFF
--- a/projects/smartcab/smartcab/environment.py
+++ b/projects/smartcab/smartcab/environment.py
@@ -176,10 +176,10 @@ class Environment(object):
             if light != 'green':
                 move_okay = False
         elif action == 'left':
-            if light == 'red' or (light == 'green' and sense['oncoming'] == 'forward'):
-                move_okay = False
-            else:
+            if light == 'green' and sense['oncoming'] != 'forward':
                 heading = turn(heading, LEFT)
+            else:
+                move_okay = False                
         elif action == 'right':
             if light == 'green' or (sense['left'] != 'forward' and sense['oncoming'] != 'left'):
                 heading = turn(heading, RIGHT)

--- a/projects/smartcab/smartcab/environment.py
+++ b/projects/smartcab/smartcab/environment.py
@@ -28,7 +28,8 @@ class Environment(object):
 
     valid_actions = [None, 'forward', 'left', 'right']
     valid_inputs = {'light': TrafficLight.valid_states, 'oncoming': valid_actions, 'left': valid_actions, 'right': valid_actions}
-    valid_headings = [(1, 0), (0, -1), (-1, 0), (0, 1)]  # ENWS
+    EAST, WEST, NORTH, SOUTH = (1, 0), (-1, 0), (0, -1), (0, 1)
+    valid_headings = [EAST, WEST, NORTH, SOUTH]
     hard_time_limit = -100  # even if enforce_deadline is False, end trial when deadline reaches this value (to avoid deadlocks)
 
     def __init__(self):
@@ -165,6 +166,9 @@ class Environment(object):
         light = 'green' if (self.intersections[location].state and heading[1] != 0) or ((not self.intersections[location].state) and heading[0] != 0) else 'red'
         sense = self.sense(agent)
 
+        LEFT, RIGHT = 1, -1
+        turn = lambda h, a: (h[1] * a, -h[0] * a)
+
         # Move agent if within bounds and obeys traffic rules
         reward = 0  # reward/penalty
         move_okay = True
@@ -172,13 +176,13 @@ class Environment(object):
             if light != 'green':
                 move_okay = False
         elif action == 'left':
-            if light == 'green' and (sense['oncoming'] == None or sense['oncoming'] == 'left'):
-                heading = (heading[1], -heading[0])
-            else:
+            if light == 'red' or (light == 'green' and sense['oncoming'] == 'forward'):
                 move_okay = False
+            else:
+                heading = turn(heading, LEFT)
         elif action == 'right':
-            if light == 'green' or sense['left'] != 'straight':
-                heading = (-heading[1], heading[0])
+            if light == 'green' or (sense['left'] != 'forward' and sense['oncoming'] != 'left'):
+                heading = turn(heading, RIGHT)
             else:
                 move_okay = False
 


### PR DESCRIPTION
### Turning Logic
Current implementation of turning logic is buggy using the formula:

| Turning Left | Turning Right |
| -----------------|------------------ |
| `x' = y`         | `x' = -y`         |
| `y' = -x`        | `y' = x`          |

These result to wrong turns when heading North or South and turning left, or heading East or West and turning right:

| Direction      | Action | New Direction     | Correct New Direction |
| ---------------- | -------- | -----------------------| ------------------------------ |
| East (1,0)     | left     | North (0, -1)         | North (0, -1)                 | 
| West (-1,0)   | left     | South (0, 1)         | South (0, 1)                   |
| North (0, -1) | left     | **East (1, 0)**      | _**West (-1, 0)**_         |
| South (0, 1)  | left     | **West (-1, 0)**   | _**East (1, 0)**_            |
| East (1,0)     | right   | **North (0, -1)**   | _**South (0, 1)**_         |
| West (-1,0)   | right   | **South (0, 1)**   | _**North (0, -1)**_         |
| North (0, -1) | right   | East (1, 0)           | East (1, 0)                     |
| South (0, 1) | right    | West (1, 0)          |  West (1, 0)                   |

To turn to the correct direction, the formula should be:

| Turning Left      | Turning Right     |
| -------------------- | --------------------- |
| `x' = y * 1 * 1`   | `x' = y * 1 * -1`   |
| `y' = x * -1 * 1`  | `y' = x * -1 * -1`  |

If we let action, a, be:
`a ∈ {LEFT = 1, RIGHT = -1}`

then we can have:
`x' = y * a`
`y' = -x * a`

for both turning left and right.


### Turning Left on Green
To be consistent with project description, it should only be okay to turn left when the light is green and there is no oncoming traffic coming forward (i.e., it is okay to turn left when `light == green && oncoming ∈ {None, left, right}`). 

However, in the current implementation, it is NOT okay to turn left when the light is green and there is an oncoming traffic turning right

### Turning Right on Red
In the current implementation, `straight` is an invalid action.

To be consistent with project description, turning right on red should also consider oncoming traffic that are turning left (although it should be expected that this will likely not occur because the light is also red for the oncoming traffic).
