### PR TITLE
Fix penalty logic for right turn

### DIFF
--- a/projects/smartcab/smartcab/environment.py
+++ b/projects/smartcab/smartcab/environment.py
@@ -205,7 +205,7 @@ class Environment(object):
             else:
                 move_okay = False
         elif action == 'right':
-            if light == 'green' or (inputs['oncoming'] != 'left' and inputs['left'] != 'forward'):
+            if light == 'green' or inputs['left'] != 'forward':
                 heading = (-heading[1], heading[0])
             else:
                 move_okay = False


### PR DESCRIPTION
When turning right on a red light, oncoming traffic is also at a red light, so no need to penalize the agent when there is oncoming traffic. Only traffic from the left going straight should be yielded to.