### PR TITLE
Set '%matplotlib inline' flag in boston-housing project visuals file.…

### DIFF
--- a/projects/boston_housing/visuals.py
+++ b/projects/boston_housing/visuals.py
@@ -5,6 +5,14 @@ import warnings
 warnings.filterwarnings("ignore", category = UserWarning, module = "matplotlib")
 ###########################################
 
+###########################################
+# Set '%matplotlib inline' flag
+# Necessary for matplotlib.pyplot to render in continuumio/anaconda docker container,
+# on Debian 8.5 distribution
+from IPython import get_ipython
+get_ipython().run_line_magic('matplotlib', 'inline')
+###########################################
+
 import matplotlib.pyplot as pl
 import numpy as np
 import sklearn.learning_curve as curves
@@ -14,7 +22,7 @@ from sklearn.cross_validation import ShuffleSplit, train_test_split
 def ModelLearning(X, y):
     """ Calculates the performance of several models with varying sizes of training data.
         The learning and testing scores for each model are then plotted. """
-    
+
     # Create 10 cross-validation sets for training and testing
     cv = ShuffleSplit(X.shape[0], n_iter = 10, test_size = 0.2, random_state = 0)
 
@@ -26,21 +34,21 @@ def ModelLearning(X, y):
 
     # Create three different models based on max_depth
     for k, depth in enumerate([1,3,6,10]):
-        
+
         # Create a Decision tree regressor at max_depth = depth
         regressor = DecisionTreeRegressor(max_depth = depth)
 
         # Calculate the training and testing scores
         sizes, train_scores, test_scores = curves.learning_curve(regressor, X, y, \
             cv = cv, train_sizes = train_sizes, scoring = 'r2')
-        
+
         # Find the mean and standard deviation for smoothing
         train_std = np.std(train_scores, axis = 1)
         train_mean = np.mean(train_scores, axis = 1)
         test_std = np.std(test_scores, axis = 1)
         test_mean = np.mean(test_scores, axis = 1)
 
-        # Subplot the learning curve 
+        # Subplot the learning curve
         ax = fig.add_subplot(2, 2, k+1)
         ax.plot(sizes, train_mean, 'o-', color = 'r', label = 'Training Score')
         ax.plot(sizes, test_mean, 'o-', color = 'g', label = 'Testing Score')
@@ -48,14 +56,14 @@ def ModelLearning(X, y):
             train_mean + train_std, alpha = 0.15, color = 'r')
         ax.fill_between(sizes, test_mean - test_std, \
             test_mean + test_std, alpha = 0.15, color = 'g')
-        
+
         # Labels
         ax.set_title('max_depth = %s'%(depth))
         ax.set_xlabel('Number of Training Points')
         ax.set_ylabel('Score')
         ax.set_xlim([0, X.shape[0]*0.8])
         ax.set_ylim([-0.05, 1.05])
-    
+
     # Visual aesthetics
     ax.legend(bbox_to_anchor=(1.05, 2.05), loc='lower left', borderaxespad = 0.)
     fig.suptitle('Decision Tree Regressor Learning Performances', fontsize = 16, y = 1.03)
@@ -66,7 +74,7 @@ def ModelLearning(X, y):
 def ModelComplexity(X, y):
     """ Calculates the performance of the model as model complexity increases.
         The learning and testing errors rates are then plotted. """
-    
+
     # Create 10 cross-validation sets for training and testing
     cv = ShuffleSplit(X.shape[0], n_iter = 10, test_size = 0.2, random_state = 0)
 
@@ -92,7 +100,7 @@ def ModelComplexity(X, y):
         train_mean + train_std, alpha = 0.15, color = 'r')
     pl.fill_between(max_depth, test_mean - test_std, \
         test_mean + test_std, alpha = 0.15, color = 'g')
-    
+
     # Visual aesthetics
     pl.legend(loc = 'lower right')
     pl.xlabel('Maximum Depth')
@@ -111,14 +119,14 @@ def PredictTrials(X, y, fitter, data):
         # Split the data
         X_train, X_test, y_train, y_test = train_test_split(X, y, \
             test_size = 0.2, random_state = k)
-        
+
         # Fit the data
         reg = fitter(X_train, y_train)
-        
+
         # Make a prediction
         pred = reg.predict([data[0]])[0]
         prices.append(pred)
-        
+
         # Result
         print "Trial {}: ${:,.2f}".format(k+1, pred)
 


### PR DESCRIPTION
This change is necessary for matplotlib.pyplot to render in continuumio/anaconda docker container, on a Debian 8.5 distribution.

Ran into significant dependency issues with jupyter notebook on OSX 10.11, so switched over to a continuumio/anaconda container, running with Docker for Mac.

In case it would be helpful:
`docker run -v /tmp/jupyter:/jupyter-working -w /jupyter-working -p 8888:8888 --rm -it continuumio/anaconda jupyter notebook --no-browser --ip="*" --notebook-dir=/jupyter-working`

Then point to http://localhost:8888.