### PR TITLE
fix: the conda channels of PyGame were misplaced

### DIFF
--- a/projects/smartcab/project_description.md
+++ b/projects/smartcab/project_description.md
@@ -20,8 +20,8 @@ This project uses the following software and Python libraries:
 If you do not have Python installed yet, it is highly recommended that you install the [Anaconda](http://continuum.io/downloads) distribution of Python, which already has the above packages and more included. Make sure that you select the Python 2.7 installer and not the Python 3.x installer. `pygame` can then be installed using one of the following commands:
 
 Mac:  `conda install -c https://conda.anaconda.org/quasiben pygame`  
-Windows: `conda install -c https://conda.anaconda.org/tlatorre pygame`  
-Linux:  `conda install -c https://conda.anaconda.org/prkrekel pygame`  
+Linux: `conda install -c https://conda.anaconda.org/tlatorre pygame` 
+Windows:  `conda install -c https://conda.anaconda.org/prkrekel pygame`  
 
 ## Fixing Common PyGame Problems
 


### PR DESCRIPTION
The conda custom channel of PyGame for linux should be tlatorre, and for windows should be prkrekel. They were misplaced.