### PR TITLE
Issue #202 - Fix warning about deprecated cross_validation module

### DIFF
--- a/projects/practice_projects/naive_bayes_tutorial/Naive_Bayes_tutorial.ipynb
+++ b/projects/practice_projects/naive_bayes_tutorial/Naive_Bayes_tutorial.ipynb
@@ -892,7 +892,7 @@
     "Solution\n",
     "'''\n",
     "# split into training and testing sets\n",
-    "from sklearn.cross_validation import train_test_split\n",
+    "from sklearn.model_selection import train_test_split\n",
     "\n",
     "X_train, X_test, y_train, y_test = train_test_split(df['sms_message'], \n",
     "                                                    df['label'], \n",


### PR DESCRIPTION
Issue #202 
```
anaconda3/lib/python3.6/site-packages/sklearn/cross_validation.py:44: DeprecationWarning: This module was deprecated in version 0.18 in favor of the model_selection module into which all the refactored classes and functions are moved. Also note that the interface of the new CV iterators are different from that of this module. This module will be removed in 0.20.
  "This module will be removed in 0.20.", DeprecationWarning
```