### PR TITLE
Update to sklearn >= 0.18

### DIFF
--- a/projects/boston_housing/boston_housing.ipynb
+++ b/projects/boston_housing/boston_housing.ipynb
@@ -42,7 +42,7 @@
     "# Import libraries necessary for this project\n",
     "import numpy as np\n",
     "import pandas as pd\n",
-    "from sklearn.cross_validation import ShuffleSplit\n",
+    "from sklearn.model_selection import ShuffleSplit\n",
     "\n",
     "# Import supplementary visualizations code visuals.py\n",
     "import visuals as vs\n",
@@ -226,7 +226,7 @@
     "Your next implementation requires that you take the Boston housing dataset and split the data into training and testing subsets. Typically, the data is also shuffled into a random order when creating the training and testing subsets to remove any bias in the ordering of the dataset.\n",
     "\n",
     "For the code cell below, you will need to implement the following:\n",
-    "- Use `train_test_split` from `sklearn.cross_validation` to shuffle and split the `features` and `prices` data into training and testing sets.\n",
+    "- Use `train_test_split` from `sklearn.model_selection` to shuffle and split the `features` and `prices` data into training and testing sets.\n",
     "  - Split the data into 80% training and 20% testing.\n",
     "  - Set the `random_state` for `train_test_split` to a value of your choice. This ensures results are consistent.\n",
     "- Assign the train and testing splits to `X_train`, `X_test`, `y_train`, and `y_test`."
@@ -416,8 +416,7 @@
     "\n",
     "In addition, you will find your implementation is using `ShuffleSplit()` for an alternative form of cross-validation (see the `'cv_sets'` variable). While it is not the K-Fold cross-validation technique you describe in **Question 8**, this type of cross-validation technique is just as useful!. The `ShuffleSplit()` implementation below will create 10 (`'n_splits'`) shuffled sets, and for each shuffle, 20% (`'test_size'`) of the data will be used as the *validation set*. While you're working on your implementation, think about the contrasts and similarities it has to the K-fold cross-validation technique.\n",
     "\n",
-    "Please note that ShuffleSplit has different parameters in scikit-learn versions 0.17 and 0.18.",
-    "\n",
+    "Please note that ShuffleSplit has different parameters in scikit-learn versions 0.17 and 0.18.\n",
     "For the `fit_model` function in the code cell below, you will need to implement the following:\n",
     "- Use [`DecisionTreeRegressor`](http://scikit-learn.org/stable/modules/generated/sklearn.tree.DecisionTreeRegressor.html) from `sklearn.tree` to create a decision tree regressor object.\n",
     "  - Assign this object to the `'regressor'` variable.\n",
@@ -615,7 +614,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.8"
+   "version": "2.7.13"
   }
  },
  "nbformat": 4,

--- a/projects/boston_housing/visuals.py
+++ b/projects/boston_housing/visuals.py
@@ -11,9 +11,9 @@ get_ipython().run_line_magic('matplotlib', 'inline')
 
 import matplotlib.pyplot as pl
 import numpy as np
-import sklearn.learning_curve as curves
+from sklearn.model_selection import validation_curve, learning_curve
 from sklearn.tree import DecisionTreeRegressor
-from sklearn.cross_validation import ShuffleSplit, train_test_split
+from sklearn.model_selection import ShuffleSplit, train_test_split
 
 def ModelLearning(X, y):
     """ Calculates the performance of several models with varying sizes of training data.
@@ -35,7 +35,7 @@ def ModelLearning(X, y):
         regressor = DecisionTreeRegressor(max_depth = depth)
 
         # Calculate the training and testing scores
-        sizes, train_scores, test_scores = curves.learning_curve(regressor, X, y, \
+        sizes, train_scores, test_scores = learning_curve(regressor, X, y, \
             cv = cv, train_sizes = train_sizes, scoring = 'r2')
         
         # Find the mean and standard deviation for smoothing
@@ -78,7 +78,7 @@ def ModelComplexity(X, y):
     max_depth = np.arange(1,11)
 
     # Calculate the training and testing scores
-    train_scores, test_scores = curves.validation_curve(DecisionTreeRegressor(), X, y, \
+    train_scores, test_scores = validation_curve(DecisionTreeRegressor(), X, y, \
         param_name = "max_depth", param_range = max_depth, cv = cv, scoring = 'r2')
 
     # Find the mean and standard deviation for smoothing


### PR DESCRIPTION
sklearn.cross_validation is now deprecated, and ShuffleSplit has a changed
signature. Given that most people doing the ND will now be on sklearn >=
0.18, it seems better to have a default that observes the new rules.