### PR TITLE
Updating boston_housing.ipynb

### DIFF
--- a/projects/boston_housing/boston_housing.ipynb
+++ b/projects/boston_housing/boston_housing.ipynb
@@ -463,6 +463,7 @@
     "  - Pass the `performance_metric` function as a parameter to the object.\n",
     "  - Assign this scoring function to the `'scoring_fnc'` variable.\n",
     "- Use [`GridSearchCV`](http://scikit-learn.org/0.17/modules/generated/sklearn.grid_search.GridSearchCV.html) from `sklearn.grid_search` to create a grid search object.\n",
+    "- (If scikit-learn version is 0.18, use [`GridSearchCV`](http://scikit-learn.org/0.18/modules/generated/sklearn.model_selection.GridSearchCV.html#sklearn.model_selection.GridSearchCV) from `sklearn.model_selection` to create a grid search object.)\n",
     "  - Pass the variables `'regressor'`, `'params'`, `'scoring_fnc'`, and `'cv_sets'` as parameters to the object. \n",
     "  - Assign the `GridSearchCV` object to the `'grid'` variable."
    ]

--- a/projects/boston_housing/boston_housing.ipynb
+++ b/projects/boston_housing/boston_housing.ipynb
@@ -463,7 +463,7 @@
     "  - Pass the `performance_metric` function as a parameter to the object.\n",
     "  - Assign this scoring function to the `'scoring_fnc'` variable.\n",
     "- Use [`GridSearchCV`](http://scikit-learn.org/0.17/modules/generated/sklearn.grid_search.GridSearchCV.html) from `sklearn.grid_search` to create a grid search object.\n",
-    "- (If scikit-learn version is 0.18, use [`GridSearchCV`](http://scikit-learn.org/0.18/modules/generated/sklearn.model_selection.GridSearchCV.html#sklearn.model_selection.GridSearchCV) from `sklearn.model_selection` to create a grid search object.)\n",
+    "- (For scikit-learn version 0.18, use [`GridSearchCV`](http://scikit-learn.org/0.18/modules/generated/sklearn.model_selection.GridSearchCV.html#sklearn.model_selection.GridSearchCV) from `sklearn.model_selection` to create a grid search object.)\n",
     "  - Pass the variables `'regressor'`, `'params'`, `'scoring_fnc'`, and `'cv_sets'` as parameters to the object. \n",
     "  - Assign the `GridSearchCV` object to the `'grid'` variable."
    ]


### PR DESCRIPTION
Section: "Implementation: Fitting a Model", add a hint for difference in scikit-learn version 0.18

'''
With scikit-learn version 0.18, GridSearchCV location is in 'sklearn.model_selection'.  
'''