### PR TITLE
image-classification - test_normalize

### DIFF
--- a/projects/image-classification/problem_unittests.py
+++ b/projects/image-classification/problem_unittests.py
@@ -40,7 +40,7 @@ def test_normalize(normalize):
     assert normalize_out.shape == test_shape,\
         'Incorrect Shape. {} shape found'.format(normalize_out.shape)
 
-    assert normalize_out.max() <= 1 and normalize_out.min() >= 0,\
+    assert normalize_out.max() == 1 and normalize_out.min() == 0,\
         'Incorect Range. {} to {} found'.format(normalize_out.min(), normalize_out.max())
 
     _print_success_message()


### PR DESCRIPTION
I improved a test to catch more types of errors.

The entire input could be normalized to a constant value and the test would pass as it is written.  It also did not catch an off by one error, meaning the input did not quite reach 1, which caused me to check out the test code.