### PR TITLE
Run smartcab easier

### DIFF
--- a/projects/smartcab/smartcab/agent.py
+++ b/projects/smartcab/smartcab/agent.py
@@ -144,14 +144,17 @@ class LearningAgent(Agent):
 def run():
     """ Driving function for running the simulation. 
         Press ESC to close the simulation, or [SPACE] to pause the simulation. """
-
+    
+    from config import command_line_parse
+    flags = command_line_parse()
+    
     ##############
     # Create the environment
     # Flags:
     #   verbose     - set to True to display additional output from the simulation
     #   num_dummies - discrete number of dummy agents in the environment, default is 100
     #   grid_size   - discrete number of intersections (columns, rows), default is (8, 6)
-    env = Environment()
+    env = Environment(**flags['env'])
     
     ##############
     # Create the driving agent
@@ -159,13 +162,13 @@ def run():
     #   learning   - set to True to force the driving agent to use Q-learning
     #    * epsilon - continuous value for the exploration factor, default is 1
     #    * alpha   - continuous value for the learning rate, default is 0.5
-    agent = env.create_agent(LearningAgent)
+    agent = env.create_agent(LearningAgent, **flags['agent'])
     
     ##############
     # Follow the driving agent
     # Flags:
     #   enforce_deadline - set to True to enforce a deadline metric
-    env.set_primary_agent(agent)
+    env.set_primary_agent(agent, **flags['deadline'])
 
     ##############
     # Create the simulation
@@ -174,15 +177,21 @@ def run():
     #   display      - set to False to disable the GUI if PyGame is enabled
     #   log_metrics  - set to True to log trial and simulation results to /logs
     #   optimized    - set to True to change the default log file name
-    sim = Simulator(env)
+    sim = Simulator(env, **flags['sim'])
     
     ##############
     # Run the simulator
     # Flags:
     #   tolerance  - epsilon tolerance before beginning testing, default is 0.05 
     #   n_test     - discrete number of testing trials to perform, default is 0
-    sim.run()
+    sim.run(**flags['run'])
 
+ # functions called in run(), necessary for config to obtain default values
+ smartcab_sim_run_funcs = (Environment.__init__,
+                          LearningAgent.__init__,
+                          Environment.set_primary_agent,
+                          Simulator.__init__,
+                          Simulator.run)
 
 if __name__ == '__main__':
     run()

--- a/projects/smartcab/smartcab/config.py
+++ b/projects/smartcab/smartcab/config.py
@@ -1,0 +1,128 @@
+import argparse
+from collections import OrderedDict
+import inspect
+from agent import smartcab_sim_run_funcs
+
+
+def categorize_flags(set_flags):
+    """
+        gives categorized keyword argument dict that functions inside run() can unpack for user-set flags
+        :param set_flags: argparse parser output of user-set flags
+        :type set_flags: dict
+        :rtype dict
+        :returns dict of section flags
+        """
+    user_flags = {cat: {flag: set_flags[flag] for flag in flag_config[cat]} for cat in flag_config}
+    return user_flags
+
+
+def set_all_defaults(parser, *funcs):
+    """
+    Set default values from function declaration so there's no mix up.
+
+    Warning: Issues may occur if default function values goes from True -> False or vice versa as in argument actions
+    in `flags` have to change from 'store_false' to 'store_true' and vice versa :type parser: argparse.ArgumentParser
+    """
+    assert all(callable(f) for f in funcs)
+    assert isinstance(parser, argparse.ArgumentParser)
+    defaults = {}
+    for f in funcs:
+        defaults.update(get_defaults(f))
+    parser.set_defaults(**defaults)
+
+
+def get_defaults(func):
+    getargspec = inspect.getargspec
+    info = getargspec(func)
+    d = len(info.defaults)
+    return {k: v for k, v in zip(info.args[-d:], info.defaults)}
+
+
+flag_categories = ['env', 'agent', 'deadline', 'sim', 'run']
+flag_config = dict(
+    env={
+        'verbose': {
+            'names': ('-v', '--verbose'),
+            'kwargs': dict(action='store_true', help='generates additional output from the simulation')
+        },
+        'num_dummies': {
+            'names': ('-N', '--num_dummies'),
+            'kwargs': dict(type=int, metavar=('INT'), help='number of dummy agents in the environment')
+        },
+        'grid_size': {
+            'names': ('-g', '--grid_size'),
+            'kwargs': dict(nargs=2, type=int, metavar=('COLS', 'ROWS'),
+                           help='controls the number of intersections = columns * rows')
+        }
+    },
+    agent={
+        'learning': {
+            'names': ('-l', '--learning'),
+            'kwargs': dict(action='store_true', help='forces the driving agent to use Q-learning')
+        },
+        'epsilon': {
+            'names': ('-e', '--epsilon'),
+            'kwargs': dict(type=float, metavar=('FLOAT'), help='NO EFFECT without -l: value for the exploration factor')
+        },
+        'alpha': {
+            'names': ('-a', '--alpha'),
+            'kwargs': dict(type=float, metavar=('FLOAT'), help='NO EFFECT without -l: value for the learning rate')
+        }
+    },
+    deadline={
+        'enforce_deadline': {
+            'names': ['-D', '--deadline'],
+            'kwargs': dict(action='store_true', dest='enforce_deadline',
+                           help='enforce a deadline metric on the driving agent')
+        }
+    },
+    sim={
+        'update_delay': {
+            'names': ('-u', '--update-delay'),
+            'kwargs': dict(type=float, metavar=('SECONDS'), help='time between actions of smartcab/environment')
+        },
+        'display': {'names': ('-d', '--display'), 'kwargs': dict(action='store_false', help='disable simulation GUI')},
+        'log_metrics': {
+            'names': ('-L', '--log'),
+            'kwargs': dict(action='store_true', dest='log_metrics', help='log trial and simulation results to /logs')
+        },
+        'optimized': {
+            'names': ('-o', '--optimized'),
+            'kwargs': dict(action='store_true', help='change the default log file name if optimized')
+        }
+    },
+    run={
+        'tolerance': {
+            'names': ('-t', '--tolerance'),
+            'kwargs': dict(type=float, metavar=('FLOAT'),
+                           help='epsilon tolerance before beginning testing after exploration')
+        },
+        'n_test': {
+            'names': ('-n', '--n_test'),
+            'kwargs': dict(type=int, metavar=('INT'), help='number of testing trials to perform')
+        }
+    })
+flag_config = OrderedDict(sorted(flag_config.items(), key=lambda t: flag_categories.index(t[0])))
+
+
+def command_line_parse():
+    """gets user-set flags from command line"""
+    parser = argparse.ArgumentParser(description='runs the smartcab simulation with various options',
+                                     usage='smartcab/agent.py [-h] [-v]'
+                                           '\n   env flags:     [-N <dummies> -g <cols> <rows>]'
+                                           '\n   drive flags:   [-l [-a <float> -e <float>]'
+                                           '\n   deadline flag: [-D]'
+                                           '\n   sim flags:     [-dLo -u <delay_secs>]'
+                                           '\n   run flags:     [-t <tolerance> -n <tests>]',
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    helps = ['environment/world options', 'driving agent options', 'deadline option',
+             'simulation options', 'run-time experiment options']
+    arg_groups = {key: parser.add_argument_group(text) for key, text in zip(flag_categories, helps)}
+    for group in flag_config:
+        for arg_name in flag_config[group]:
+            d = flag_config[group][arg_name]
+            arg_groups[group].add_argument(*d['names'], **d['kwargs'])
+    set_all_defaults(parser, *smartcab_sim_run_funcs)
+    flat_flags = vars(parser.parse_args())
+    flat_flags['grid_size'] = tuple(flat_flags['grid_size'])
+    return categorize_flags(flat_flags)


### PR DESCRIPTION
This improvement makes it unnecessary to muck about in the code to change experiment defaults. Now simply pass flags from the command line! Help text and argument parsing (with helpful errors!) are included.

Also, if a smartcab experiment default float, int, or tuple changes in the code base (say in simulation.py or LearningAgent), the function inspector will pick it up and change the based default flag automatically.

Care must be taken changing from a default value of `False -> True` or `True -> False`, since that requires the corresponding config action to be changed from `'store_true'` to `'store_false'`. A future improvement might help that. 

Hope you guys appreciate it! It was a great learning experience for me, though I might've been better served completing the project haha. 