### PR TITLE
visuals.py now runs in both python 2 and 3

### DIFF
--- a/projects/finding_donors/visuals.py
+++ b/projects/finding_donors/visuals.py
@@ -72,11 +72,11 @@ def evaluate(results, accuracy, f1):
             for i in np.arange(3):
                 
                 # Creative plot code
-                ax[j/3, j%3].bar(i+k*bar_width, results[learner][i][metric], width = bar_width, color = colors[k])
-                ax[j/3, j%3].set_xticks([0.45, 1.45, 2.45])
-                ax[j/3, j%3].set_xticklabels(["1%", "10%", "100%"])
-                ax[j/3, j%3].set_xlabel("Training Set Size")
-                ax[j/3, j%3].set_xlim((-0.1, 3.0))
+                ax[j//3, j%3].bar(i+k*bar_width, results[learner][i][metric], width = bar_width, color = colors[k])
+                ax[j//3, j%3].set_xticks([0.45, 1.45, 2.45])
+                ax[j//3, j%3].set_xticklabels(["1%", "10%", "100%"])
+                ax[j//3, j%3].set_xlabel("Training Set Size")
+                ax[j//3, j%3].set_xlim((-0.1, 3.0))
     
     # Add unique y-labels
     ax[0, 0].set_ylabel("Time (in seconds)")


### PR DESCRIPTION
Currently students running the notebook in python 3 get the following error when calling `vs.evaluate(results, accuracy, fscore)`:

> IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices

The fix forces floor division, so the code will run in both python 2 and python 3.