### PR TITLE
Removing reference to deprecated code

### DIFF
--- a/projects/boston_housing/boston_housing.ipynb
+++ b/projects/boston_housing/boston_housing.ipynb
@@ -42,7 +42,7 @@
     "# Import libraries necessary for this project\n",
     "import numpy as np\n",
     "import pandas as pd\n",
-    "from sklearn.cross_validation import ShuffleSplit\n",
+    "from sklearn.model_selection import ShuffleSplit\n",
     "\n",
     "# Import supplementary visualizations code visuals.py\n",
     "import visuals as vs\n",


### PR DESCRIPTION
The code provided has been deprecated, and I recommend replacing it with the latest Sklearn module to suppress error (and be up-to-date)