### PR TITLE
fix: Swap X_train and y_train to work with visuals

### DIFF
--- a/projects/boston_housing/boston_housing.ipynb
+++ b/projects/boston_housing/boston_housing.ipynb
@@ -349,7 +349,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vs.ModelComplexity(X_train, y_train)"
+    "vs.ModelComplexity(y_train, X_train)"
    ]
   },
   {
@@ -529,7 +529,7 @@
    "outputs": [],
    "source": [
     "# Fit the training data to the model using grid search\n",
-    "reg = fit_model(X_train, y_train)\n",
+    "reg = fit_model(y_train, X_train)\n",
     "\n",
     "# Produce the value for 'max_depth'\n",
     "print(\"Parameter 'max_depth' is {} for the optimal model.\".format(reg.get_params()['max_depth']))"


### PR DESCRIPTION
Error was due to X_train's shape in vs.ModelComplexity which pops out from 
curves.validation_curve. X_train's shape also gives error in fit_model method.