### PR TITLE
fixing docs for url of jupyter notebook issue  #345

### DIFF
--- a/projects/boston_housing/README.md
+++ b/projects/boston_housing/README.md
@@ -11,7 +11,7 @@ This project requires **Python** and the following Python libraries installed:
 - [matplotlib](http://matplotlib.org/)
 - [scikit-learn](http://scikit-learn.org/stable/)
 
-You will also need to have software installed to run and execute a [Jupyter Notebook](http://ipython.org/notebook.html)
+You will also need to have software installed to run and execute a [Jupyter Notebook](http://jupyter.org/index.html)
 
 If you do not have Python installed yet, it is highly recommended that you install the [Anaconda](http://continuum.io/downloads) distribution of Python, which already has the above packages and more included. 
 

--- a/projects/boston_housing/project_description.md
+++ b/projects/boston_housing/project_description.md
@@ -26,7 +26,7 @@ This project uses the following software and Python libraries:
 - [scikit-learn](http://scikit-learn.org/stable/)
 - [matplotlib](http://matplotlib.org/)
 
-You will also need to have software installed to run and execute a [Jupyter Notebook](http://ipython.org/notebook.html).
+You will also need to have software installed to run and execute a [Jupyter Notebook](http://jupyter.org/index.html).
 
 If you do not have Python installed yet, it is highly recommended that you install the [Anaconda](http://continuum.io/downloads) distribution of Python, which already has the above packages and more included. 
 

--- a/projects/customer_segments/README.md
+++ b/projects/customer_segments/README.md
@@ -10,7 +10,7 @@ This project requires **Python 2.7** and the following Python libraries installe
 - [matplotlib](http://matplotlib.org/)
 - [scikit-learn](http://scikit-learn.org/stable/)
 
-You will also need to have software installed to run and execute a [Jupyter Notebook](http://ipython.org/notebook.html)
+You will also need to have software installed to run and execute a [Jupyter Notebook](http://jupyter.org/index.html)
 
 If you do not have Python installed yet, it is highly recommended that you install the [Anaconda](http://continuum.io/downloads) distribution of Python, which already has the above packages and more included. Make sure that you select the Python 2.7 installer and not the Python 3.x installer. 
 

--- a/projects/customer_segments/project_description.md
+++ b/projects/customer_segments/project_description.md
@@ -28,7 +28,7 @@ This project uses the following software and Python libraries:
 - [scikit-learn](http://scikit-learn.org/stable/)
 - [matplotlib](http://matplotlib.org/)
 
-You will also need to have software installed to run and execute a [Jupyter Notebook](http://ipython.org/notebook.html).
+You will also need to have software installed to run and execute a [Jupyter Notebook](http://jupyter.org/index.html).
 
 If you do not have Python installed yet, it is highly recommended that you install the [Anaconda](http://continuum.io/downloads) distribution of Python, which already has the above packages and more included. Make sure that you select the Python 2.7 installer and not the Python 3.x installer.
 

--- a/projects/digit_recognition/README.md
+++ b/projects/digit_recognition/README.md
@@ -11,7 +11,7 @@ This project requires **Python 2.x or Python 3.x** and the following Python libr
 - [scikit-learn](http://scikit-learn.org/0.17/install.html) (v0.17)
 - [TensorFlow](http://tensorflow.org)
 
-You will also need to have software installed to run and execute a [Jupyter Notebook](http://ipython.org/notebook.html).
+You will also need to have software installed to run and execute a [Jupyter Notebook](http://jupyter.org/index.html).
 
 In addition to the above, for those optionally seeking to use image processing software, you may need one of the following:
 - [PyGame](http://pygame.org/)

--- a/projects/digit_recognition/project_description.md
+++ b/projects/digit_recognition/project_description.md
@@ -14,7 +14,7 @@ This project uses the following software and Python libraries:
 - [scikit-learn](http://scikit-learn.org/0.17/install.html) (v0.17)
 - [TensorFlow](http://tensorflow.org)
 
-You will also need to have software installed to run and execute a [Jupyter Notebook](http://ipython.org/notebook.html).
+You will also need to have software installed to run and execute a [Jupyter Notebook](http://jupyter.org/index.html).
 
 In addition to the above, for those optionally seeking to use image processing software, you may need one of the following:
 - [PyGame](http://pygame.org/)

--- a/projects/finding_donors/README.md
+++ b/projects/finding_donors/README.md
@@ -11,7 +11,7 @@ This project requires **Python 2.7** and the following Python libraries installe
 - [matplotlib](http://matplotlib.org/)
 - [scikit-learn](http://scikit-learn.org/stable/)
 
-You will also need to have software installed to run and execute an [iPython Notebook](http://ipython.org/notebook.html)
+You will also need to have software installed to run and execute an [iPython Notebook](http://jupyter.org/index.html)
 
 We recommend students install [Anaconda](https://www.continuum.io/downloads), a pre-packaged Python distribution that contains all of the necessary libraries and software for this project. 
 

--- a/projects/finding_donors/project_description.md
+++ b/projects/finding_donors/project_description.md
@@ -24,7 +24,7 @@ This project uses the following software and Python libraries:
 - [scikit-learn](http://scikit-learn.org/stable/)
 - [matplotlib](http://matplotlib.org/)
 
-You will also need to have software installed to run and execute a [Jupyter Notebook](http://ipython.org/notebook.html)
+You will also need to have software installed to run and execute a [Jupyter Notebook](http://jupyter.org/index.html)
 
 If you do not have Python installed yet, it is highly recommended that you install the [Anaconda](http://continuum.io/downloads) distribution of Python, which already has the above packages and more included. Make sure that you select the Python 2.7 installer and not the Python 3.x installer.
 

--- a/projects/student_intervention/README.md
+++ b/projects/student_intervention/README.md
@@ -10,7 +10,7 @@ This project requires **Python 2.7** and the following Python libraries installe
 - [Pandas](http://pandas.pydata.org)
 - [scikit-learn](http://scikit-learn.org/stable/)
 
-You will also need to have software installed to run and execute a [Jupyter Notebook](http://ipython.org/notebook.html)
+You will also need to have software installed to run and execute a [Jupyter Notebook](http://jupyter.org/index.html)
 
 If you do not have Python installed yet, it is highly recommended that you install the [Anaconda](http://continuum.io/downloads) distribution of Python, which already has the above packages and more included. Make sure that you select the Python 2.7 installer and not the Python 3.x installer.
 

--- a/projects/student_intervention/project_description.md
+++ b/projects/student_intervention/project_description.md
@@ -15,7 +15,7 @@ This project uses the following software and Python libraries:
 - [pandas](http://pandas.pydata.org/)
 - [scikit-learn](http://scikit-learn.org/0.17/install.html) (v0.17)
 
-You will also need to have software installed to run and execute a [Jupyter Notebook](http://ipython.org/notebook.html).
+You will also need to have software installed to run and execute a [Jupyter Notebook](http://jupyter.org/index.html).
 
 If you do not have Python installed yet, it is highly recommended that you install the [Anaconda](http://continuum.io/downloads) distribution of Python, which already has the above packages and more included. Make sure that you select the Python 2.7 installer and not the Python 3.x installer.
 

--- a/projects/titanic_survival_exploration/README.md
+++ b/projects/titanic_survival_exploration/README.md
@@ -11,7 +11,7 @@ This project requires **Python** and the following Python libraries installed:
 - [matplotlib](http://matplotlib.org/)
 - [scikit-learn](http://scikit-learn.org/stable/)
 
-You will also need to have software installed to run and execute a [Jupyter Notebook](http://ipython.org/notebook.html)
+You will also need to have software installed to run and execute a [Jupyter Notebook](http://jupyter.org/index.html)
 
 If you do not have Python installed yet, it is highly recommended that you install the [Anaconda](http://continuum.io/downloads) distribution of Python, which already has the above packages and more included
 

--- a/projects/titanic_survival_exploration/project_description.md
+++ b/projects/titanic_survival_exploration/project_description.md
@@ -16,7 +16,7 @@ This project uses the following software and Python libraries:
 - [pandas](http://pandas.pydata.org/)
 - [matplotlib](http://matplotlib.org/)
 
-You will also need to have software installed to run and execute a [Jupyter Notebook](http://ipython.org/notebook.html).
+You will also need to have software installed to run and execute a [Jupyter Notebook](http://jupyter.org/index.html).
 
 If you do not have Python installed yet, it is highly recommended that you install the [Anaconda](http://continuum.io/downloads) distribution of Python, which already has the above packages and more included.
 


### PR DESCRIPTION
Latest url : `http://jupyter.org/install`
url being used: `http://ipython.org/notebook.html`

`https://github.com/udacity/machine-learning/issues/345`