### PR TITLE
Boston Housing compatibility with scikit-learn version 0.20+

### DIFF
--- a/projects/boston_housing/boston_housing.ipynb
+++ b/projects/boston_housing/boston_housing.ipynb
@@ -40,7 +40,7 @@
     "# Import libraries necessary for this project\n",
     "import numpy as np\n",
     "import pandas as pd\n",
-    "from sklearn.cross_validation import ShuffleSplit\n",
+    "from sklearn.model_selection import ShuffleSplit\n",
     "\n",
     "# Import supplementary visualizations code visuals.py\n",
     "import visuals as vs\n",
@@ -240,7 +240,7 @@
     "Your next implementation requires that you take the Boston housing dataset and split the data into training and testing subsets. Typically, the data is also shuffled into a random order when creating the training and testing subsets to remove any bias in the ordering of the dataset.\n",
     "\n",
     "For the code cell below, you will need to implement the following:\n",
-    "- Use `train_test_split` from `sklearn.cross_validation` to shuffle and split the `features` and `prices` data into training and testing sets.\n",
+    "- Use `train_test_split` from `sklearn.model_selection` to shuffle and split the `features` and `prices` data into training and testing sets.\n",
     "  - Split the data into 80% training and 20% testing.\n",
     "  - Set the `random_state` for `train_test_split` to a value of your choice. This ensures results are consistent.\n",
     "- Assign the train and testing splits to `X_train`, `X_test`, `y_train`, and `y_test`."
@@ -447,7 +447,6 @@
     "\n",
     "In addition, you will find your implementation is using `ShuffleSplit()` for an alternative form of cross-validation (see the `'cv_sets'` variable). While it is not the K-Fold cross-validation technique you describe in **Question 8**, this type of cross-validation technique is just as useful!. The `ShuffleSplit()` implementation below will create 10 (`'n_splits'`) shuffled sets, and for each shuffle, 20% (`'test_size'`) of the data will be used as the *validation set*. While you're working on your implementation, think about the contrasts and similarities it has to the K-fold cross-validation technique.\n",
     "\n",
-    "Please note that ShuffleSplit has different parameters in scikit-learn versions 0.17 and 0.18.\n",
     "For the `fit_model` function in the code cell below, you will need to implement the following:\n",
     "- Use [`DecisionTreeRegressor`](http://scikit-learn.org/stable/modules/generated/sklearn.tree.DecisionTreeRegressor.html) from `sklearn.tree` to create a decision tree regressor object.\n",
     "  - Assign this object to the `'regressor'` variable.\n",
@@ -455,7 +454,7 @@
     "- Use [`make_scorer`](http://scikit-learn.org/stable/modules/generated/sklearn.metrics.make_scorer.html) from `sklearn.metrics` to create a scoring function object.\n",
     "  - Pass the `performance_metric` function as a parameter to the object.\n",
     "  - Assign this scoring function to the `'scoring_fnc'` variable.\n",
-    "- Use [`GridSearchCV`](http://scikit-learn.org/0.17/modules/generated/sklearn.grid_search.GridSearchCV.html) from `sklearn.grid_search` to create a grid search object.\n",
+    "- Use [`GridSearchCV`](http://scikit-learn.org/0.20/modules/generated/sklearn.model_selection.GridSearchCV.html) from `sklearn.model_selection` to create a grid search object.\n",
     "  - Pass the variables `'regressor'`, `'params'`, `'scoring_fnc'`, and `'cv_sets'` as parameters to the object. \n",
     "  - Assign the `GridSearchCV` object to the `'grid'` variable."
    ]
@@ -475,9 +474,7 @@
     "        decision tree regressor trained on the input data [X, y]. \"\"\"\n",
     "    \n",
     "    # Create cross-validation sets from the training data\n",
-    "    # sklearn version 0.18: ShuffleSplit(n_splits=10, test_size=0.1, train_size=None, random_state=None)\n",
-    "    # sklearn versiin 0.17: ShuffleSplit(n, n_iter=10, test_size=0.1, train_size=None, random_state=None)\n",
-    "    cv_sets = ShuffleSplit(X.shape[0], n_iter = 10, test_size = 0.20, random_state = 0)\n",
+    "    cv_sets = ShuffleSplit(n_splits = 10, test_size = 0.20, random_state = 0)\n",
     "\n",
     "    # TODO: Create a decision tree regressor object\n",
     "    regressor = None\n",
@@ -660,7 +657,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/projects/boston_housing/visuals.py
+++ b/projects/boston_housing/visuals.py
@@ -11,16 +11,17 @@ get_ipython().run_line_magic('matplotlib', 'inline')
 
 import matplotlib.pyplot as pl
 import numpy as np
-import sklearn.learning_curve as curves
+from sklearn.model_selection import learning_curve
+from sklearn.model_selection import validation_curve
 from sklearn.tree import DecisionTreeRegressor
-from sklearn.cross_validation import ShuffleSplit, train_test_split
+from sklearn.model_selection import ShuffleSplit, train_test_split
 
 def ModelLearning(X, y):
     """ Calculates the performance of several models with varying sizes of training data.
         The learning and testing scores for each model are then plotted. """
-    
+
     # Create 10 cross-validation sets for training and testing
-    cv = ShuffleSplit(X.shape[0], n_iter = 10, test_size = 0.2, random_state = 0)
+    cv = ShuffleSplit(n_splits = 10, test_size = 0.2, random_state = 0)
 
     # Generate the training set sizes increasing by 50
     train_sizes = np.rint(np.linspace(1, X.shape[0]*0.8 - 1, 9)).astype(int)
@@ -30,21 +31,21 @@ def ModelLearning(X, y):
 
     # Create three different models based on max_depth
     for k, depth in enumerate([1,3,6,10]):
-        
+
         # Create a Decision tree regressor at max_depth = depth
         regressor = DecisionTreeRegressor(max_depth = depth)
 
         # Calculate the training and testing scores
-        sizes, train_scores, test_scores = curves.learning_curve(regressor, X, y, \
+        sizes, train_scores, test_scores = learning_curve(regressor, X, y, \
             cv = cv, train_sizes = train_sizes, scoring = 'r2')
-        
+
         # Find the mean and standard deviation for smoothing
         train_std = np.std(train_scores, axis = 1)
         train_mean = np.mean(train_scores, axis = 1)
         test_std = np.std(test_scores, axis = 1)
         test_mean = np.mean(test_scores, axis = 1)
 
-        # Subplot the learning curve 
+        # Subplot the learning curve
         ax = fig.add_subplot(2, 2, k+1)
         ax.plot(sizes, train_mean, 'o-', color = 'r', label = 'Training Score')
         ax.plot(sizes, test_mean, 'o-', color = 'g', label = 'Testing Score')
@@ -52,14 +53,14 @@ def ModelLearning(X, y):
             train_mean + train_std, alpha = 0.15, color = 'r')
         ax.fill_between(sizes, test_mean - test_std, \
             test_mean + test_std, alpha = 0.15, color = 'g')
-        
+
         # Labels
         ax.set_title('max_depth = %s'%(depth))
         ax.set_xlabel('Number of Training Points')
         ax.set_ylabel('Score')
         ax.set_xlim([0, X.shape[0]*0.8])
         ax.set_ylim([-0.05, 1.05])
-    
+
     # Visual aesthetics
     ax.legend(bbox_to_anchor=(1.05, 2.05), loc='lower left', borderaxespad = 0.)
     fig.suptitle('Decision Tree Regressor Learning Performances', fontsize = 16, y = 1.03)
@@ -70,15 +71,15 @@ def ModelLearning(X, y):
 def ModelComplexity(X, y):
     """ Calculates the performance of the model as model complexity increases.
         The learning and testing errors rates are then plotted. """
-    
+
     # Create 10 cross-validation sets for training and testing
-    cv = ShuffleSplit(X.shape[0], n_iter = 10, test_size = 0.2, random_state = 0)
+    cv = ShuffleSplit(n_splits = 10, test_size = 0.2, random_state = 0)
 
     # Vary the max_depth parameter from 1 to 10
     max_depth = np.arange(1,11)
 
     # Calculate the training and testing scores
-    train_scores, test_scores = curves.validation_curve(DecisionTreeRegressor(), X, y, \
+    train_scores, test_scores = validation_curve(DecisionTreeRegressor(), X, y, \
         param_name = "max_depth", param_range = max_depth, cv = cv, scoring = 'r2')
 
     # Find the mean and standard deviation for smoothing
@@ -96,7 +97,7 @@ def ModelComplexity(X, y):
         train_mean + train_std, alpha = 0.15, color = 'r')
     pl.fill_between(max_depth, test_mean - test_std, \
         test_mean + test_std, alpha = 0.15, color = 'g')
-    
+
     # Visual aesthetics
     pl.legend(loc = 'lower right')
     pl.xlabel('Maximum Depth')
@@ -115,14 +116,14 @@ def PredictTrials(X, y, fitter, data):
         # Split the data
         X_train, X_test, y_train, y_test = train_test_split(X, y, \
             test_size = 0.2, random_state = k)
-        
+
         # Fit the data
         reg = fitter(X_train, y_train)
-        
+
         # Make a prediction
         pred = reg.predict([data[0]])[0]
         prices.append(pred)
-        
+
         # Result
         print("Trial {}: ${:,.2f}".format(k+1, pred))
 


### PR DESCRIPTION
Hello, because `scikit-learn` version `0.20` was [released 2 days ago](https://pypi.org/project/scikit-learn/#history), students now run their projects having this version installed.

As a result, the backwards compatibility with older versions of imports and function arguments is gone (sklearn was backwards-compatible up to 0.19). 

**The Study Hall is full of questions regarding this—please update the project template asap. Thank you!**