### PR TITLE
Fix parenthesis error

### DIFF
--- a/projects/practice_projects/naive_bayes_tutorial/Bayesian_Inference_solution.ipynb
+++ b/projects/practice_projects/naive_bayes_tutorial/Bayesian_Inference_solution.ipynb
@@ -1134,8 +1134,8 @@
     "\n",
     "# P(~D|Pos)\n",
     "p_no_diabetes_pos = (p_no_diabetes * p_pos_no_diabetes) / p_pos\n",
-    "print 'Probability of an individual not having diabetes, given that that individual got a positive test result is:'\\\n",
-    ",p_no_diabetes_pos"
+    "print ('Probability of an individual not having diabetes, given that that individual got a positive test result is:'\\\n",
+    ",p_no_diabetes_pos)"
    ]
   },
   {


### PR DESCRIPTION
This PR solves

```R
SyntaxError: Missing parentheses in call to 'print'. Did you mean print('Probability of an individual not having diabetes, given that that individual got a positive test result is:',p_no_diabetes_pos)?
```
In
```Python
'''
Solution
'''
# P(Pos/~D)
p_pos_no_diabetes = 0.1

# P(~D|Pos)
p_no_diabetes_pos = (p_no_diabetes * p_pos_no_diabetes) / p_pos
print 'Probability of an individual not having diabetes, given that that individual got a positive test result is:'\
, p_no_diabetes_pos
```
