### PR TITLE
url changed to http://jupyter.org/install #345

### DIFF
--- a/projects/boston_housing/README.md
+++ b/projects/boston_housing/README.md
@@ -11,7 +11,7 @@ This project requires **Python** and the following Python libraries installed:
 - [matplotlib](http://matplotlib.org/)
 - [scikit-learn](http://scikit-learn.org/stable/)
 
-You will also need to have software installed to run and execute a [Jupyter Notebook](http://ipython.org/notebook.html)
+You will also need to have software installed to run and execute a [Jupyter Notebook](http://jupyter.org/install)
 
 If you do not have Python installed yet, it is highly recommended that you install the [Anaconda](http://continuum.io/downloads) distribution of Python, which already has the above packages and more included. 
 


### PR DESCRIPTION
Fixed issue #345
Changed URL from http://ipython.org/notebook.html to http://jupyter.org/install in boston_housing