### PR TITLE
Use train_test_split under sklearn.model_selection

### DIFF
--- a/projects/finding_donors/finding_donors.ipynb
+++ b/projects/finding_donors/finding_donors.ipynb
@@ -356,7 +356,7 @@
    "outputs": [],
    "source": [
     "# Import train_test_split\n",
-    "from sklearn.cross_validation import train_test_split\n",
+    "from sklearn.model_selection import train_test_split\n",
     "\n",
     "# Split the 'features' and 'income' data into training and testing sets\n",
     "X_train, X_test, y_train, y_test = train_test_split(features_final, \n",


### PR DESCRIPTION
recent versions (at least >=0.20.x) of sklearn have train_test_split under the module `model_selection` and not `cross_validation`  

link: https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.train_test_split.html

stacktrace I got when running the notebook:

```
-----------------------------------
ModuleNotFoundErrorTraceback (most recent call last)
<ipython-input-34-ce9dd2d5e4df> in <module>
      1 # Import train_test_split
----> 2 from sklearn.cross_validation import train_test_split
      3 
      4 # Split the 'features' and 'income' data into training and testing sets
      5 X_train, X_test, y_train, y_test = train_test_split(features_final, 

ModuleNotFoundError: No module named 'sklearn.cross_validation'
```