### PR TITLE
Update GridSearchCV import path

### DIFF
--- a/projects/finding_donors/finding_donors.ipynb
+++ b/projects/finding_donors/finding_donors.ipynb
@@ -676,7 +676,7 @@
    "source": [
     "### Implementation: Model Tuning\n",
     "Fine tune the chosen model. Use grid search (`GridSearchCV`) with at least one important parameter tuned with at least 3 different values. You will need to use the entire training set for this. In the code cell below, you will need to implement the following:\n",
-    "- Import [`sklearn.grid_search.GridSearchCV`](http://scikit-learn.org/0.17/modules/generated/sklearn.grid_search.GridSearchCV.html) and [`sklearn.metrics.make_scorer`](http://scikit-learn.org/stable/modules/generated/sklearn.metrics.make_scorer.html).\n",
+    "- Import [`sklearn.model_selection.GridSearchCV`](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.GridSearchCV.html) and [`sklearn.metrics.make_scorer`](http://scikit-learn.org/stable/modules/generated/sklearn.metrics.make_scorer.html).\n",
     "- Initialize the classifier you've chosen and store it in `clf`.\n",
     " - Set a `random_state` if one is available to the same state you set before.\n",
     "- Create a dictionary of parameters you wish to tune for the chosen model.\n",


### PR DESCRIPTION
GridSearchCV is now under sklearn.model_selection   (sklearn v0.20.x)

link: https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.GridSearchCV.html